### PR TITLE
Stop using RTTI and make controller decide using message-id

### DIFF
--- a/SnakeController/SnakeController.cpp
+++ b/SnakeController/SnakeController.cpp
@@ -215,22 +215,26 @@ Controller::Segment Controller::getNewHead() const
 
 void Controller::receive(std::unique_ptr<Event> e)
 {
-    try {
-        handleTimePassed(*dynamic_cast<EventT<TimeoutInd> const&>(*e));
-    } catch (std::bad_cast&) {
-        try {
-            handleDirectionChange(*dynamic_cast<EventT<DirectionInd> const&>(*e));
-        } catch (std::bad_cast&) {
-            try {
-                handleFoodPositionChange(*dynamic_cast<EventT<FoodInd> const&>(*e));
-            } catch (std::bad_cast&) {
-                try {
-                    handleNewFood(*dynamic_cast<EventT<FoodResp> const&>(*e));
-                } catch (std::bad_cast&) {
-                    throw UnexpectedEventException();
-                }
-            }
-        }
+    switch (e->getMessageId()) {
+
+	    case TimeoutInd::MESSAGE_ID:
+		    handleTimePassed(payload<TimeoutInd>(*(e.get())));
+		    break;
+
+	    case DirectionInd::MESSAGE_ID:
+		    handleDirectionChange(payload<DirectionInd>(*(e.get())));
+		    break;
+
+	    case FoodInd::MESSAGE_ID:
+		    handleFoodPositionChange(payload<FoodInd>(*(e.get())));
+		    break;
+
+	    case FoodResp::MESSAGE_ID:
+		    handleNewFood(payload<FoodResp>(*(e.get())));
+		    break;
+
+	    default:
+		    throw UnexpectedEventException();
     }
 }
 


### PR DESCRIPTION
I decided to use `payload<T>` function

Student 25  
Bartosz Rodziewicz